### PR TITLE
Fix jstl jar packaging corruption.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,6 @@
           <webResources>
             <resource>
               <directory>src/main/webapp</directory>
-                <filtering>true</filtering>
             </resource>
           </webResources>
         </configuration>


### PR DESCRIPTION
Filtering caused the war packaging to corrupt the jstl-1.2.jar file.  Removed it from the pom.xml.